### PR TITLE
Use framework paginator for better support of magic pagination

### DIFF
--- a/Events/Events.php
+++ b/Events/Events.php
@@ -68,4 +68,9 @@ class Events
                 return carbon($event->start_date)->setTimeFromTimeString($event->startTime());
             })->values();
     }
+
+    public function count()
+    {
+        return $this->events->count();
+    }
 }

--- a/Events/EventsTags.php
+++ b/Events/EventsTags.php
@@ -8,9 +8,10 @@ use Statamic\API\URL;
 use Statamic\API\Request;
 use Spatie\CalendarLinks\Link;
 use Illuminate\Support\Collection;
-use Illuminate\Pagination\Paginator;
 use Statamic\Addons\Events\EventFactory;
+use Statamic\Presenters\PaginationPresenter;
 use Statamic\Addons\Collection\CollectionTags;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class EventsTags extends CollectionTags
 {
@@ -119,8 +120,11 @@ class EventsTags extends CollectionTags
 
         $events = $this->events->upcoming($this->limit + 1, $this->offset);
 
-        $paginator = new Paginator(
+        $count = $this->events->count();
+
+        $paginator = new LengthAwarePaginator(
             $events,
+            $count,
             $this->limit,
             $page
         );
@@ -129,8 +133,14 @@ class EventsTags extends CollectionTags
         $paginator->appends(Request::all());
 
         $this->paginationData = [
-            'prev_page' => $paginator->previousPageUrl(),
-            'next_page' => $paginator->nextPageUrl(),
+            'total_items'    => $count,
+            'items_per_page' => $this->limit,
+            'total_pages'    => $paginator->lastPage(),
+            'current_page'   => $paginator->currentPage(),
+            'prev_page'      => $paginator->previousPageUrl(),
+            'next_page'      => $paginator->nextPageUrl(),
+            'auto_links'     => $paginator->render(),
+            'links'          => $paginator->render(new PaginationPresenter($paginator))
         ];
 
         $this->dates = $events->slice(0, $this->limit);


### PR DESCRIPTION
This switches the basic Pagination to the `Illuminate\Pagination\LengthAwarePaginator` so that it becomes possible to use the `{{ auto_links }}` tag from core. It also adds the `count` method on to Events, which was previously inaccessible because the actual events collection is a private property on the Events class.